### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ Last thing I tried was cherrypicking these: https://gerrit.omnirom.org/#/c/4834/
 // Follow http://wiki.cyanogenmod.org/w/Build_for_one to get all prerequisites until: "Initialize the CyanogenMod source repository"
 
 // Download Cyanogenmod 11.0 into working directory (take a double coffee)
-- cd ~/android/system/
-- repo init -u https://github.com/CyanogenMod/android.git -b cm-11.0
-- repo sync
+- `cd ~/android/system/`
+- `repo init -u https://github.com/CyanogenMod/android.git -b cm-11.0`
+- `repo sync`
 
 // Get FP1 specific Android Kernel and Android Device (take a coffee): Copy local_manifest.xml into .repo/local_manifests and then
-- repo sync
+- `repo sync`
 
 // Check if you have succesfully downloaded folders kernel/fp/ and device/fp
 
 // Get proprietary builds (ADB connect your device)
-- cd fp/FP1
-- ./extract-files.sh
+- `cd device/fp/FP1`
+- `./extract-files.sh`
 
 // Check if there is a folder vendor/fp/FP1 and if it's full according to list in extract-files.sh
 
 //Start building (take a double coffee)
-- croot
-- . build/envsetup.sh
-- brunch FP1
+- `. build/envsetup.sh`
+- `croot`
+- `brunch FP1`
 
 #Errors:
 - If build fails due to "make: *** No rule to make target 'vendor/fp/FP1/proprietary/lib/hw/audio.primary.mt6589.so', needed by '/home/martin/android/system/out/target/product/FP1/system/lib/hw/audio.primary.mt6589.so'.  Stop."


### PR DESCRIPTION
add code ticks and swap order of `envsetup` and `croot` because `croot` gets added WITH `envsetup`
